### PR TITLE
add `remark-d2` to list of extensions

### DIFF
--- a/docs/tour/extensions.md
+++ b/docs/tour/extensions.md
@@ -38,3 +38,4 @@ issue and we're happy to include your's!
 - MongoDB to D2: [https://github.com/novuhq/mongo-to-D2](https://github.com/novuhq/mongo-to-D2)
 - Pandoc filter: [https://github.com/ram02z/d2-filter](https://github.com/ram02z/d2-filter)
 - MySQL to D2: [https://github.com/JDOsborne1/db_to_d2](https://github.com/JDOsborne1/db_to_d2)
+- Remark D2 code blocks into images: [https://github.com/mech-a/remark-d2](https://github.com/mech-a/remark-d2)


### PR DESCRIPTION
I've made a plugin for [remark](https://github.com/remarkjs/remark) that compiles d2 code blocks into images, like so:

````md
# Some sample Markdown

```d2 width=100px;p=center
cool->language
```
````
becomes
```md
# Some sample Markdown

<img alt="d2 diagram" width="100px" position="center" src="static/d2/..." />
```

On the side, since it's built on remark, you can also add it into Docusaurus with ease. I'm not sure if you all have a way to compile the D2 written in your documentation or if you duplicate it, but if you'd like to compile the D2 written in your Markdown directly when you build the site, you can add it in [following these instructions](https://docusaurus.io/docs/markdown-features/math-equations#upgrading-rehype-katex-beyond-recommended-version).
