### PR TITLE
[extensions] add d2-diagrams-icons

### DIFF
--- a/docs/tour/extensions.md
+++ b/docs/tour/extensions.md
@@ -42,3 +42,4 @@ issue and we're happy to include your's!
 - D2 image service: [https://github.com/Watt3r/d2-live](https://github.com/Watt3r/d2-live)
 - MkDocs plugin: [https://github.com/landmaj/mkdocs-d2-plugin](https://github.com/landmaj/mkdocs-d2-plugin)
 - C# & dotnet SDK: [https://github.com/Stephanvs/d2lang-cs](https://github.com/Stephanvs/d2lang-cs)
+- Diagrams icons for D2: [https://github.com/denis-ismailaj/d2-diagrams-icons](https://github.com/denis-ismailaj/d2-diagrams-icons)


### PR DESCRIPTION
`d2-diagrams-icons` provides a `D2` template which supplies the icons included in [`mingrammer/diagrams`](https://github.com/mingrammer/diagrams)

The goal is to make the migration from `diagrams` to `D2` easier, but also to help others get started without worrying about finding and adding icons are that commonly used in software architecture diagrams.