### PR TITLE
add zed extension

### DIFF
--- a/docs/tour/extensions.md
+++ b/docs/tour/extensions.md
@@ -42,3 +42,4 @@ issue and we're happy to include your's!
 - D2 image service: [https://github.com/Watt3r/d2-live](https://github.com/Watt3r/d2-live)
 - MkDocs plugin: [https://github.com/landmaj/mkdocs-d2-plugin](https://github.com/landmaj/mkdocs-d2-plugin)
 - C# & dotnet SDK: [https://github.com/Stephanvs/d2lang-cs](https://github.com/Stephanvs/d2lang-cs)
+- Zed extension: [https://github.com/gabeidx/zed-d2](https://github.com/gabeidx/zed-d2)


### PR DESCRIPTION
This PR adds a reference to the D2 Zed extension: <https://github.com/gabeidx/zed-d2>.