### PR TITLE
update link documentation on URIs requiring quoting if they contain a fragment

### DIFF
--- a/docs/tour/interactive.md
+++ b/docs/tour/interactive.md
@@ -41,6 +41,12 @@ tooltips.
 
 Links are like tooltips, except you click to go to an external link.
 
+:::info
+When the link contains the `#` character as part of a URI fragment, e.g.,
+`https://example.com/page#fragment`, remember that the fragment will be
+treated as a comment if unquoted and unescaped.
+:::
+
 <CodeBlock className="language-d2">
     {Links}
 </CodeBlock>


### PR DESCRIPTION
As described in this [d2 repo issue](https://github.com/terrastruct/d2/issues/2239).