### PR TITLE
Fix go install script

### DIFF
--- a/docs/tour/install.md
+++ b/docs/tour/install.md
@@ -37,7 +37,7 @@ curl -fsSL https://d2lang.com/install.sh | sh -s -- --uninstall
 Alternatively, you can install from source:
 
 ```shell
-go install oss.terrastruct.com/d2
+go install oss.terrastruct.com/d2@latest
 ```
 
 


### PR DESCRIPTION
Add `@latest` to go install script since just `go install oss.terrastruct.com/d2` is not valid. Error message:

```
go: 'go install' requires a version when current directory is not in a module
        Try 'go install oss.terrastruct.com/d2@latest' to install the latest version
```