### PR TITLE
fix: restrict Node.js 22.7.x to avoid encoding issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": ">=16.14.0 <22.7.0 || >=22.8.0"
+  },
   "private": true,
   "scripts": {
     "dev": "docusaurus start --port 8888",


### PR DESCRIPTION
## Description

- Node.js 22.7.x has encoding issues when building CSS files, causing pagination arrows (» and «) to be rendered as question marks (?).
- close #253

## Testing

- Node.js 22.7.0 (build blocked as expected)
- Node.js 20.18.0 (working)
- Node.js 18.20.0 (working)

### Additional Notes

The minimum Node.js version ([16.14.0](https://docusaurus.io/docs/2.x/installation#requirements)) is required by Docusaurus 2.4.3. The upper version restriction (excluding 22.7.x) is added to avoid the character encoding issues during build.