### PR TITLE
docs: fix typo in font flags

### DIFF
--- a/docs/tour/fonts.md
+++ b/docs/tour/fonts.md
@@ -27,7 +27,7 @@ d2 --font-regular=./helvetica-regular.ttf input.d2
 It's advisable to supply either none or all of the fonts, for consistency. If you supply
 one but not all of the fonts, it will fall back to Source Sans Pro for the missing styles.
 For example, if you give a `--font-regular`, `--font-bold`, and `--font-semibold`, then the
-talic will remain as Source Sans Pro Italic.
+italic will remain as Source Sans Pro Italic.
 
 :::info
 Do you want to customize the fonts for code or sketch mode? Please raise an Issue on


### PR DESCRIPTION
Realized I made a typo, missing `i` in italic in the change of https://github.com/terrastruct/d2-docs/pull/275