### PR TITLE
fix: update tour/strings next page link

### DIFF
--- a/docs/tour/strings.md
+++ b/docs/tour/strings.md
@@ -1,5 +1,5 @@
 ---
-pagination_next: tour/comments
+pagination_next: tour/vars
 ---
 import CodeBlock from '@theme/CodeBlock';
 import Strings2 from '@site/static/d2/strings-2.d2';


### PR DESCRIPTION
https://d2lang.com/tour/strings/ currently links to https://d2lang.com/tour/comments/ as the next page, which skips over the "Variables & Substitutions" and "Globs" sections.