### PR TITLE
Update documentation links for d2lang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/d2-vscode"]
 	path = src/d2-vscode
-	url = https://github.com/terrastruct/d2-vscode
+	url = https://github.com/d2lang/d2-vscode
 [submodule "ci/sub"]
 	path = ci/sub
 	url = https://github.com/terrastruct/ci

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # D2 Documentation
 
-[![ci](https://github.com/terrastruct/d2-docs/actions/workflows/ci.yml/badge.svg)](https://github.com/terrastruct/d2-docs/actions/workflows/ci.yml)
-[![daily](https://github.com/terrastruct/d2-docs/actions/workflows/daily.yml/badge.svg)](https://github.com/terrastruct/d2-docs/actions/workflows/daily.yml)
-[![license](https://img.shields.io/github/license/terrastruct/d2-docs?color=9cf)](./LICENSE)
+[![ci](https://github.com/d2lang/d2-docs/actions/workflows/ci.yml/badge.svg)](https://github.com/d2lang/d2-docs/actions/workflows/ci.yml)
+[![daily](https://github.com/d2lang/d2-docs/actions/workflows/daily.yml/badge.svg)](https://github.com/d2lang/d2-docs/actions/workflows/daily.yml)
+[![license](https://img.shields.io/github/license/d2lang/d2-docs?color=9cf)](./LICENSE)
 
 This is language documentation for D2, a modern, open-source text-to-diagram DSL. The
 source repository for that is here:
-[https://github.com/terrastruct/d2](https://github.com/terrastruct/d2).
+[https://github.com/d2lang/d2](https://github.com/d2lang/d2).
 
 Deployed at [https://d2lang.com](https://d2lang.com).
 

--- a/blog/animation.md
+++ b/blog/animation.md
@@ -8,7 +8,7 @@ This is a single SVG file created purely through D2 text:
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/animated.svg2')}}></div>
 
-> D2 source to reproduce this is here: [here](https://github.com/terrastruct/d2-docs/blob/master/static/bespoke-d2/animated.d2), rendered with [these parameters](https://github.com/terrastruct/d2-docs/blob/master/ci/render.sh#L12).
+> D2 source to reproduce this is here: [here](https://github.com/d2lang/d2-docs/blob/master/static/bespoke-d2/animated.d2), rendered with [these parameters](https://github.com/d2lang/d2-docs/blob/master/ci/render.sh#L12).
 
 
 Brief factsheet:
@@ -52,11 +52,11 @@ Or a journey to build up to something.
 
 D2 is not yet 1.0. Of the many things planned in the near term, better ergonomics for
 creating these are a priority. The source code for all of these diagrams can be found
-[here](https://github.com/terrastruct/d2-docs/tree/master/static/bespoke-d2). Some of
+[here](https://github.com/d2lang/d2-docs/tree/master/static/bespoke-d2). Some of
 these are currently verbose and repetitive. We've released early to get feedback from the
 community, but in-progress things like globs (being able to target objects with `*`) and
 classes will make creating these animations much easier than they currently are.
 
 `--animate-interval` is available to use in D2 0.3.0 ([install
-here](https://github.com/terrastruct/d2#install)), hope you can check it out and let us
+here](https://github.com/d2lang/d2#install)), hope you can check it out and let us
 know what you think!

--- a/blog/ascii.md
+++ b/blog/ascii.md
@@ -17,7 +17,7 @@ d2 in.d2 out.txt
 
 <!-- truncate -->
 
-Here is an example of their rendering from the [D2 Vim extension](https://github.com/terrastruct/d2-vim). The user opens a `.d2` file and opens a preview window, which updates upon every save.
+Here is an example of their rendering from the [D2 Vim extension](https://github.com/d2lang/d2-vim). The user opens a `.d2` file and opens a preview window, which updates upon every save.
 
 ![D2 Vim preview](/blog/ascii/preview.gif)
 
@@ -44,7 +44,7 @@ the flag `--ascii-mode=standard`.
 Note that the ASCII renderer should be considered in alpha stage. There will be many
 corner cases, areas of improvements, and outright bugs. If you enjoy using it, we'd
 appreciate you taking the time to file any issues you run into:
-[https://github.com/terrastruct/d2/issues](https://github.com/terrastruct/d2/issues).
+[https://github.com/d2lang/d2/issues](https://github.com/d2lang/d2/issues).
 :::
 
 The ASCII renderer is a downscale of the layout determined by the ELK layout engine with

--- a/blog/dark_mode.md
+++ b/blog/dark_mode.md
@@ -4,7 +4,7 @@ title: Dark-mode responsive diagrams
 description: How diagrams in D2 are responsive to dark mode
 slug: dark-mode
 tags: [dark mode, show-and-tell]
-image: https://raw.githubusercontent.com/terrastruct/d2-docs/master/static/img/blog/dark_mode.png
+image: https://raw.githubusercontent.com/d2lang/d2-docs/master/static/img/blog/dark_mode.png
 hide_table_of_contents: false
 ---
 import WebPImage from '@site/src/components/WebPImage';

--- a/blog/powerpoint.md
+++ b/blog/powerpoint.md
@@ -4,7 +4,7 @@ title: Text to PowerPoint
 description: Creating PowerPoint presentations from text with diagrams
 slug: powerpoint
 tags: [powerpoint, show-and-tell]
-image: https://raw.githubusercontent.com/terrastruct/d2-docs/master/static/img/screenshots/wcc_pptx.png
+image: https://raw.githubusercontent.com/d2lang/d2-docs/master/static/img/screenshots/wcc_pptx.png
 hide_table_of_contents: false
 ---
 import CodeBlock from '@theme/CodeBlock';
@@ -16,7 +16,7 @@ create full PowerPoint presentations with just text.
 
 It's not D2's primary function, but rather a natural byproduct of a powerful language. D2
 built features for grid diagrams and animations, and users built [pixel
-art](https://github.com/terrastruct/d2/issues/1218#issuecomment-1512628007). And now, with
+art](https://github.com/d2lang/d2/issues/1218#issuecomment-1512628007). And now, with
 Markdown and Powerpoint, D2 is the easiest way to programmatically create PowerPoint
 presentations.
 
@@ -52,7 +52,7 @@ Be sure to go into Present mode to click on objects and navigate around.
 - Download: [wcc.pptx](pathname:///img/generated/wcc.pptx)
 - Google Slides: [https://docs.google.com/presentation/d/18rRh4izu3k_43On8PXtVYdqRxmoQJd4y/view](https://docs.google.com/presentation/d/18rRh4izu3k_43On8PXtVYdqRxmoQJd4y/view)
 
-The source code for this is a bit longer, and can be found [here](https://github.com/terrastruct/d2/blob/master/docs/examples/wcc/wcc.d2).
+The source code for this is a bit longer, and can be found [here](https://github.com/d2lang/d2/blob/master/docs/examples/wcc/wcc.d2).
 
 ## Limitations
 

--- a/blog/sketch.md
+++ b/blog/sketch.md
@@ -4,7 +4,7 @@ title: Hand-drawn diagram aesthetic
 description: How you can make diagrams look hand-drawn in D2
 slug: hand-drawn-diagrams
 tags: [hand-drawn, show-and-tell]
-image: https://raw.githubusercontent.com/terrastruct/d2-docs/master/static/img/blog/sketch.png
+image: https://raw.githubusercontent.com/d2lang/d2-docs/master/static/img/blog/sketch.png
 hide_table_of_contents: false
 ---
 import CodeBlock from '@theme/CodeBlock';

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -26,4 +26,4 @@ and more. Some of these examples originally were split into multiple files, and 
 combined for a simplified gallery.
 
 We welcome contributions. These are all open-source; simply submit a PR
-[here](https://github.com/terrastruct/d2-docs/tree/master/ci/examples).
+[here](https://github.com/d2lang/d2-docs/tree/master/ci/examples).

--- a/docs/releases/0.7.1.md
+++ b/docs/releases/0.7.1.md
@@ -1,25 +1,25 @@
 #### Features 🚀
 
-- ASCII renders. Output `txt` for d2 to render diagrams as ASCII art [#2572](https://github.com/terrastruct/d2/pull/2572)
-- `cross` arrowhead shape is available [#2190](https://github.com/terrastruct/d2/pull/2190)
-- `style.underline` support for class fields and methods [#2544](https://github.com/terrastruct/d2/pull/2544)
-- markdown, latex, and code can be used as edge labels [#2545](https://github.com/terrastruct/d2/pull/2545)
-- border-x label positioning functionality [#2549](https://github.com/terrastruct/d2/pull/2549)
-- tooltips with `near` set always show even without hover [#2564](https://github.com/terrastruct/d2/pull/2564)
-- CLI supports customizing monospace fonts with `--font-mono`, `--font-mono-bold`, `--font-mono-italic`, and `--font-mono-semibold` flags [#2590](https://github.com/terrastruct/d2/pull/2590)
+- ASCII renders. Output `txt` for d2 to render diagrams as ASCII art [#2572](https://github.com/d2lang/d2/pull/2572)
+- `cross` arrowhead shape is available [#2190](https://github.com/d2lang/d2/pull/2190)
+- `style.underline` support for class fields and methods [#2544](https://github.com/d2lang/d2/pull/2544)
+- markdown, latex, and code can be used as edge labels [#2545](https://github.com/d2lang/d2/pull/2545)
+- border-x label positioning functionality [#2549](https://github.com/d2lang/d2/pull/2549)
+- tooltips with `near` set always show even without hover [#2564](https://github.com/d2lang/d2/pull/2564)
+- CLI supports customizing monospace fonts with `--font-mono`, `--font-mono-bold`, `--font-mono-italic`, and `--font-mono-semibold` flags [#2590](https://github.com/d2lang/d2/pull/2590)
 
 #### Improvements 🧹
 
-- labels on scenario/step boards can be set with primary value (like layers) [#2579](https://github.com/terrastruct/d2/pull/2579)
-- autoformatter preserves order of boards [#2580](https://github.com/terrastruct/d2/pull/2580)
-- rename "Legend" with a title/label of your choosing (especially useful for non-English diagrams) [#2582](https://github.com/terrastruct/d2/pull/2582)
-- sketch mode fonts will use custom fonts if provided [#2582](https://github.com/terrastruct/d2/pull/2591)
+- labels on scenario/step boards can be set with primary value (like layers) [#2579](https://github.com/d2lang/d2/pull/2579)
+- autoformatter preserves order of boards [#2580](https://github.com/d2lang/d2/pull/2580)
+- rename "Legend" with a title/label of your choosing (especially useful for non-English diagrams) [#2582](https://github.com/d2lang/d2/pull/2582)
+- sketch mode fonts will use custom fonts if provided [#2582](https://github.com/d2lang/d2/pull/2591)
 
 #### Bugfixes ⛑️
 
-- actors in sequence diagrams with labels and icons together no longer overlap, position keywords now work too [#2548](https://github.com/terrastruct/d2/pull/2548)
-- fix double glob behavior in scenarios (wasn't propagating correctly) [#2557](https://github.com/terrastruct/d2/pull/2557)
-- fix diagram bounding box not accounting for legend in some cases [#2584](https://github.com/terrastruct/d2/pull/2584)
+- actors in sequence diagrams with labels and icons together no longer overlap, position keywords now work too [#2548](https://github.com/d2lang/d2/pull/2548)
+- fix double glob behavior in scenarios (wasn't propagating correctly) [#2557](https://github.com/d2lang/d2/pull/2557)
+- fix diagram bounding box not accounting for legend in some cases [#2584](https://github.com/d2lang/d2/pull/2584)
 
 #### Breaking Changes
 
@@ -27,4 +27,4 @@
 
 ---
 
-For the latest d2.js changes, see separate [changelog](https://github.com/terrastruct/d2/blob/master/d2js/js/CHANGELOG.md).
+For the latest d2.js changes, see separate [changelog](https://github.com/d2lang/d2/blob/master/d2js/js/CHANGELOG.md).

--- a/docs/releases/intro.md
+++ b/docs/releases/intro.md
@@ -4,7 +4,7 @@
 
 Version: [0.7.1](/releases/0.7.1) (released August 19, 2025)
 
-Downloads: [Assets](https://github.com/terrastruct/d2/releases/tag/v0.7.1)
+Downloads: [Assets](https://github.com/d2lang/d2/releases/tag/v0.7.1)
 
 :::
 

--- a/docs/tour/api.md
+++ b/docs/tour/api.md
@@ -7,7 +7,7 @@ pagination_next: tour/man
 D2 has an API built on top of its AST for **programmatically creating diagrams in Go**.
 This package is `d2/d2oracle`.
 
-This API is exercised heavily by Terrastruct to implement [bidirectional edits](https://youtu.be/EhxVVkxv2Ns?t=150). We have [comprehensive test coverage](https://github.com/terrastruct/d2/blob/master/d2oracle/edit_test.go) of these functions. If there's any confusion from the docs, there's almost certainly a test that answers your question. (We're also happy to help, just file a GitHub issue!)
+This API is exercised heavily by Terrastruct to implement [bidirectional edits](https://youtu.be/EhxVVkxv2Ns?t=150). We have [comprehensive test coverage](https://github.com/d2lang/d2/blob/master/d2oracle/edit_test.go) of these functions. If there's any confusion from the docs, there's almost certainly a test that answers your question. (We're also happy to help, just file a GitHub issue!)
 
 For a blog post detailing an example usage (building a SQL table diagram), see [https://terrastruct.com/blog/post/generate-diagrams-programmatically/](https://terrastruct.com/blog/post/generate-diagrams-programmatically/).
 

--- a/docs/tour/community.md
+++ b/docs/tour/community.md
@@ -4,7 +4,7 @@
   href="https://discord.gg/NF6X8K4eDq">https://discord.gg/NF6X8K4eDq</a>. If you have a
   question or need help, you'll find responses quickest through this channel.
 - Have a proposal, running into a bug, or anything else you want to discuss with the team
-  and community? D2 uses [GitHub Issues](https://github.com/terrastruct/d2) to track all
-  TODOs, and [GitHub Discussions](https://github.com/terrastruct/d2/discussions) for
+  and community? D2 uses [GitHub Issues](https://github.com/d2lang/d2) to track all
+  TODOs, and [GitHub Discussions](https://github.com/d2lang/d2/discussions) for
   feature requests and ideas.
 - If you have a private enquiry, please email us: hi@d2lang.com.

--- a/docs/tour/editor-support.md
+++ b/docs/tour/editor-support.md
@@ -5,8 +5,8 @@ We have first class language support for both Vim and VS Code.
 Automatic indentation and syntax highlighting are fully supported and make working with
 the D2 language far more pleasant.
 
-- https://github.com/terrastruct/d2-vim
-- https://github.com/terrastruct/d2-vscode
+- https://github.com/d2lang/d2-vim
+- https://github.com/d2lang/d2-vscode
 
 The syntax highlighting will even catch basic errors for you if your color theme
 highlights illegal syntax.

--- a/docs/tour/exports.md
+++ b/docs/tour/exports.md
@@ -62,7 +62,7 @@ npm install -g @playwright
 npx playwright install --with-deps chromium
 ```
 
-See [#744](https://github.com/terrastruct/d2/issues/744#issuecomment-1446641870) for more.
+See [#744](https://github.com/d2lang/d2/issues/744#issuecomment-1446641870) for more.
 :::
 
 ## PDF

--- a/docs/tour/faq.md
+++ b/docs/tour/faq.md
@@ -56,12 +56,12 @@ instructions and examples so you can include it in your browser projects.
 ...e.g., an item in the middle of a venn diagram.
 
 Not currently and not in the near future. See
-[discussion](https://github.com/terrastruct/d2/discussions/328) for more.
+[discussion](https://github.com/d2lang/d2/discussions/328) for more.
 
 ### Can I specify ports?
 
 Not currently, but in the near future. See
-[discussion](https://github.com/terrastruct/d2/discussions/605) for more.
+[discussion](https://github.com/d2lang/d2/discussions/605) for more.
 
 ## Exports
 
@@ -107,4 +107,3 @@ tldr; when it's treated as an image, the interactivity is lost.
     </tr>
   </tbody>
 </table>
-

--- a/docs/tour/future.md
+++ b/docs/tour/future.md
@@ -3,7 +3,7 @@
 import WebPImage from '@site/src/components/WebPImage';
 
 :::info TLDR
-[https://github.com/terrastruct/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature](https://github.com/terrastruct/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature)
+[https://github.com/d2lang/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature](https://github.com/d2lang/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature)
 :::
 
 D2's long-term goal is to significantly reduce the amount of time and effort it takes to
@@ -152,7 +152,7 @@ unforeseen ones for the infinite workflows out there.
 D2's plugin system further makes the language extensible. These allow you to add "hooks"
 to stages of D2 compilation. For example, while not core to D2, a hypothetical set of
 plugins can add a styled border, add your signature/credits, make everything [look
-hand-drawn](https://github.com/terrastruct/d2/pull/91), then increase contrast for
+hand-drawn](https://github.com/d2lang/d2/pull/91), then increase contrast for
 accessibility.
 
 ### How success is measured
@@ -185,7 +185,7 @@ unplanned usage.
 ## Your feedback
 
 If you have any suggestions or feedback, we'd love to hear from you! Please open an issue
-on [Github](https://github.com/terrastruct/d2).
+on [Github](https://github.com/d2lang/d2).
 
 ## Notes
 
@@ -203,7 +203,7 @@ widely released and their live editor still won't allow it.
 visit [https://terrastruct.com/tala](https://terrastruct.com/tala).
 
 [4] If you still miss the hand-drawn aesthetic, D2 has just the thing:
-https://github.com/terrastruct/d2/pull/492
+https://github.com/d2lang/d2/pull/492
 
 [5] Actually, gopls single-handedly brings my machine back to 2005 speeds with how much
 CPU it consumes. Not the fault of vim-go though!

--- a/docs/tour/grid-diagrams.md
+++ b/docs/tour/grid-diagrams.md
@@ -108,7 +108,7 @@ It would do the opposite.
 :::info
 These animations are also pure D2, so you can animate grid diagrams being built-up. Use
 the `animate-interval` flag with this
-[code](https://github.com/terrastruct/d2-docs/blob/f5c762223ce192338d9d7865df3ca8533d683cdc/static/bespoke-d2/grid-row-dominant.d2#L1).
+[code](https://github.com/d2lang/d2-docs/blob/f5c762223ce192338d9d7865df3ca8533d683cdc/static/bespoke-d2/grid-row-dominant.d2#L1).
 More on this later, in the [composition](/tour/composition/) section.
 :::
 
@@ -131,7 +131,7 @@ Setting `grid-gap` is equivalent to setting both `vertical-gap` and `horizontal-
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/japan.svg2')}}></div>
 
-> [D2 source](https://github.com/terrastruct/d2/blob/master/docs/examples/japan-grid/japan.d2)
+> [D2 source](https://github.com/d2lang/d2/blob/master/docs/examples/japan-grid/japan.d2)
 
 #### Or a table of data
 
@@ -160,7 +160,7 @@ Connections for grids themselves work normally as you'd expect.
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/grid-connected.svg2')}}></div>
 
-> Source code [here](https://github.com/terrastruct/d2-docs/blob/eda2d8739ce21c656e7608be48cb9067df36eb53/static/d2/grid-connected.d2).
+> Source code [here](https://github.com/d2lang/d2-docs/blob/eda2d8739ce21c656e7608be48cb9067df36eb53/static/d2/grid-connected.d2).
 
 ### Connections between grid cells
 
@@ -171,11 +171,11 @@ i.e., no path-finding.
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/grid-connections.svg2')}}></div>
 
-> Source code [here](https://github.com/terrastruct/d2/blob/master/e2etests/testdata/files/simple_grid_edges.d2).
+> Source code [here](https://github.com/d2lang/d2/blob/master/e2etests/testdata/files/simple_grid_edges.d2).
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/grid-nested-connections.svg2')}}></div>
 
-> Source code [here](https://github.com/terrastruct/d2/blob/master/docs/examples/vector-grid/vector-grid.d2).
+> Source code [here](https://github.com/d2lang/d2/blob/master/docs/examples/vector-grid/vector-grid.d2).
 
 ## Nesting
 

--- a/docs/tour/help.md
+++ b/docs/tour/help.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Contributions are welcome! Please see the full doc on contributing on D2's Github:
-[https://github.com/terrastruct/d2/blob/master/docs/CONTRIBUTING.md](https://github.com/terrastruct/d2/blob/master/docs/CONTRIBUTING.md).
+[https://github.com/d2lang/d2/blob/master/docs/CONTRIBUTING.md](https://github.com/d2lang/d2/blob/master/docs/CONTRIBUTING.md).
 
 ## Help wanted
 
@@ -12,11 +12,11 @@ Below is a list of features that could use your help. If you're interested in ta
 initiative, feel free to just start, or you can comment on a GitHub issue, discuss in
 Discord, or email us (alex at terrastruct).
 
-- [ownCloud Infinite Scale Extension](https://github.com/terrastruct/d2/issues/1422)
-- [IntelliJ plugin](https://github.com/terrastruct/d2/issues/747)
-- [Chocolatey package](https://github.com/terrastruct/d2/issues/154)
-- [Docusaurus plugin](https://github.com/terrastruct/d2/issues/1448)
-- [Visual Studio Extension](https://github.com/terrastruct/d2/discussions/237)
-- [PrismJS highlighter](https://github.com/terrastruct/d2-docs/issues/185)
+- [ownCloud Infinite Scale Extension](https://github.com/d2lang/d2/issues/1422)
+- [IntelliJ plugin](https://github.com/d2lang/d2/issues/747)
+- [Chocolatey package](https://github.com/d2lang/d2/issues/154)
+- [Docusaurus plugin](https://github.com/d2lang/d2/issues/1448)
+- [Visual Studio Extension](https://github.com/d2lang/d2/discussions/237)
+- [PrismJS highlighter](https://github.com/d2lang/d2-docs/issues/185)
 
 Want to add something to this wishlist? Just make an Issue on D2's GitHub!

--- a/docs/tour/install.md
+++ b/docs/tour/install.md
@@ -5,7 +5,7 @@ pagination_next: tour/hello-world
 
 :::tip
 There are more detailed install instructions for Mac, Windows, and Linux, using a variety of
-methods, [here](https://github.com/terrastruct/d2/blob/master/docs/INSTALL.md). This page
+methods, [here](https://github.com/d2lang/d2/blob/master/docs/INSTALL.md). This page
 is an abridged version.
 :::
 
@@ -44,7 +44,7 @@ go install oss.terrastruct.com/d2@latest
 :::info
 You can also download precompiled binaries specific to your OS on the Github releases
 page:
-[https://github.com/terrastruct/d2/releases](https://github.com/terrastruct/d2/releases).
+[https://github.com/d2lang/d2/releases](https://github.com/d2lang/d2/releases).
 :::
 
 # Try it out

--- a/docs/tour/intro.md
+++ b/docs/tour/intro.md
@@ -36,10 +36,10 @@ href="/tour/hello-world/">Getting Started</a> takes
 
 :::info
 The source code for D2 is hosted here:
-[https://github.com/terrastruct/d2](https://github.com/terrastruct/d2).
+[https://github.com/d2lang/d2](https://github.com/d2lang/d2).
 
 The source code for these docs are here:
-[https://github.com/terrastruct/d2-docs](https://github.com/terrastruct/d2-docs).
+[https://github.com/d2lang/d2-docs](https://github.com/d2lang/d2-docs).
 :::
 
 :::info

--- a/docs/tour/man.md
+++ b/docs/tour/man.md
@@ -60,7 +60,7 @@ OPTIONS
 		 Be aware that explicit styles set in D2 code will still be
 		 applied and this may produce unexpected results. We plan on
 		 resolving this by making style maps in D2 light/dark mode
-		 specific. See https://github.com/terrastruct/d2/issues/831.
+		 specific. See https://github.com/d2lang/d2/issues/831.
 
      -s, --sketch false
 		 Renders the diagram to look like it was sketched by hand.

--- a/docs/tour/obsidian.md
+++ b/docs/tour/obsidian.md
@@ -12,4 +12,4 @@ Currently it only supports rendering of D2 diagrams.
 
 
 **Github:**
-[https://github.com/terrastruct/d2-obsidian](https://github.com/terrastruct/d2-obsidian)
+[https://github.com/d2lang/d2-obsidian](https://github.com/d2lang/d2-obsidian)

--- a/docs/tour/vim.md
+++ b/docs/tour/vim.md
@@ -1,10 +1,10 @@
 # Vim plugin
 
 D2 has an official, creator-maintained plugin for Vim. You can use any plugin manager to
-include `terrastruct/d2-vim`. For example:
+include `d2lang/d2-vim`. For example:
 
 ```
-Plug 'terrastruct/d2-vim'
+Plug 'd2lang/d2-vim'
 ```
 
 Automatic indentation and syntax highlighting are fully supported and make working with
@@ -14,4 +14,4 @@ The syntax highlighting will even catch basic errors for you if your color theme
 highlights illegal syntax.
 
 **Github:**
-[https://github.com/terrastruct/d2-vim](https://github.com/terrastruct/d2-vim)
+[https://github.com/d2lang/d2-vim](https://github.com/d2lang/d2-vim)

--- a/docs/tour/vscode.md
+++ b/docs/tour/vscode.md
@@ -13,5 +13,4 @@ The syntax highlighting will even catch basic errors for you if your color theme
 highlights illegal syntax.
 
 **Github:**
-[https://github.com/terrastruct/d2-vscode](https://github.com/terrastruct/d2-vscode)
-
+[https://github.com/d2lang/d2-vscode](https://github.com/d2lang/d2-vscode)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -41,10 +41,7 @@ const config: Config = {
           name: "Terrastruct",
           url: "https://terrastruct.com",
         },
-        sameAs: [
-          "https://github.com/d2lang/d2",
-          "https://discord.com/invite/pbUXgvmTpU",
-        ],
+        sameAs: ["https://github.com/d2lang/d2", "https://discord.com/invite/pbUXgvmTpU"],
       }),
     },
     {

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -42,7 +42,7 @@ const config: Config = {
           url: "https://terrastruct.com",
         },
         sameAs: [
-          "https://github.com/terrastruct/d2",
+          "https://github.com/d2lang/d2",
           "https://discord.com/invite/pbUXgvmTpU",
         ],
       }),
@@ -189,7 +189,7 @@ const config: Config = {
           icon: {
             alt: "github logo",
             src: `/logos/github.svg`,
-            href: "https://github.com/terrastruct/d2",
+            href: "https://github.com/d2lang/d2",
             target: "_blank",
           },
         },

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/community.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/community.md
@@ -1,5 +1,5 @@
 # 커뮤니티
 
 - 질문이나 도움이 필요한 경우 [Discord 채널](https://discord.gg/NF6X8K4eDq)을 통해 빠르게 답변을 받으실 수 있습니다.
-- 제안, 버그 발생 또는 팀 및 커뮤니티와 논의하고 싶은 사항이 있으신가요? D2는 [GitHub Issues](https://github.com/terrastruct/d2/issues)를 사용하여 이슈들을 관리하고 있으며, [GitHub Discussions](https://github.com/terrastruct/d2/discussions)으로 기능 요청 및 아이디어를 확인하고 있습니다.
+- 제안, 버그 발생 또는 팀 및 커뮤니티와 논의하고 싶은 사항이 있으신가요? D2는 [GitHub Issues](https://github.com/d2lang/d2/issues)를 사용하여 이슈들을 관리하고 있으며, [GitHub Discussions](https://github.com/d2lang/d2/discussions)으로 기능 요청 및 아이디어를 확인하고 있습니다.
 - 개인적인 문의사항이 있으신 경우 hi@d2lang.com으로 이메일을 보내주세요.

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/future.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/future.md
@@ -3,7 +3,7 @@
 import WebPImage from '@site/src/components/WebPImage';
 
 :::info 간략 요약
-D2 프로젝트의 현재 작업들에 대한 자세한 내용은 [여기](https://github.com/terrastruct/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature)를 확인하세요.
+D2 프로젝트의 현재 작업들에 대한 자세한 내용은 [여기](https://github.com/d2lang/d2/issues?q=is%3Aopen+is%3Aissue+label%3Afeature)를 확인하세요.
 :::
 
 D2 프로젝트의 장기적인 목표는 실무에서 쓰이는 높은 수준의 다이어그램을 만들고 유지하는 데 소요되는 시간과 노력을 크게 줄이는 것입니다.
@@ -130,7 +130,7 @@ D2에는 공식 Vim 및 VSCode 확장이 있습니다.
 
 D2의 플러그인 시스템은 이 언어를 더욱 확장 가능하게 만듭니다.
 이를 통해 사용자는 D2 컴파일 과정의 여러 단계에 "훅(hooks)"을 추가할 수 있습니다.
-예를 들어, D2의 핵심 기능은 아니지만, 가상의 플러그인 세트를 사용하여 스타일이 있는 테두리를 추가하고, 사용자의 서명이나 크레딧을 추가하며, 모든 것을 [손으로 그린 것처럼 보이게](https://github.com/terrastruct/d2/pull/91)<sup><a id="sup4" href="#note4">[4]</a></sup> 할 수 있고, 접근성을 높이기 위해 대비를 증가시킬 수 있습니다.
+예를 들어, D2의 핵심 기능은 아니지만, 가상의 플러그인 세트를 사용하여 스타일이 있는 테두리를 추가하고, 사용자의 서명이나 크레딧을 추가하며, 모든 것을 [손으로 그린 것처럼 보이게](https://github.com/d2lang/d2/pull/91)<sup><a id="sup4" href="#note4">[4]</a></sup> 할 수 있고, 접근성을 높이기 위해 대비를 증가시킬 수 있습니다.
 
 ### 평가 방법
 
@@ -167,7 +167,7 @@ D2의 플러그인이 그렇게 되어서는 안되겠죠.
 ## 여러분의 피드백
 
 제안 사항이나 피드백이 있으시면 언제든지 알려주세요!
-[Github](https://github.com/terrastruct/d2)에서 이슈를 열어주세요.
+[Github](https://github.com/d2lang/d2)에서 이슈를 열어주세요.
 
 ## 주석
 
@@ -195,7 +195,7 @@ MermaidJS는 컨테이너에 대한 지원도 구현한 것으로 보이지만 �
 
 <a id="note4" href="#sup4">[4] </a>
 
-수작업의 ​​낭만을 원한다면 D2에서 도와드릴 수 있습니다. [링크](https://github.com/terrastruct/d2/pull/492)를 참고하세요.
+수작업의 ​​낭만을 원한다면 D2에서 도와드릴 수 있습니다. [링크](https://github.com/d2lang/d2/pull/492)를 참고하세요.
 
 <a id="note5" href="#sup5">[5] </a>
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/grid-diagrams.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/grid-diagrams.md
@@ -121,7 +121,7 @@ grid-rows: 4
 :::info
 위의 애니메이션은 D2만으로 구현되었습니다.
 즉, 그리드 다이어그램의 구성 과정을 애니메이션화 할 수 있습니다.
-이 [코드](https://github.com/terrastruct/d2-docs/blob/f5c762223ce192338d9d7865df3ca8533d683cdc/static/bespoke-d2/grid-row-dominant.d2)와 함께 `animate-interval` 플래그를 사용하세요.
+이 [코드](https://github.com/d2lang/d2-docs/blob/f5c762223ce192338d9d7865df3ca8533d683cdc/static/bespoke-d2/grid-row-dominant.d2)와 함께 `animate-interval` 플래그를 사용하세요.
 이에 대한 자세한 내용은 뒤에 나오는 [composition](/tour/composition/) 섹션에서 확인하세요.
 :::
 
@@ -143,7 +143,7 @@ grid-rows: 4
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/japan.svg2')}}></div>
 
-> [소스 코드](https://github.com/terrastruct/d2/blob/master/docs/examples/japan-grid/japan.d2)
+> [소스 코드](https://github.com/d2lang/d2/blob/master/docs/examples/japan-grid/japan.d2)
 
 ### 또는 테이블형 데이터에도 저장 가능합니다.
 
@@ -189,7 +189,7 @@ D2의 일반 객체처럼 그리드와 다른 객체를 연결할 수 있습니�
 
 <div className="embedSVG" dangerouslySetInnerHTML={{__html: require('@site/static/img/generated/grid-connected.svg2')}}></div>
 
-> [소스 코드](https://github.com/terrastruct/d2-docs/blob/eda2d8739ce21c656e7608be48cb9067df36eb53/static/d2/grid-connected.d2)
+> [소스 코드](https://github.com/d2lang/d2-docs/blob/eda2d8739ce21c656e7608be48cb9067df36eb53/static/d2/grid-connected.d2)
 
 ## 중첩
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/install.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/install.md
@@ -5,7 +5,7 @@ pagination_next: tour/hello-world
 # 설치하기
 
 :::tip
-[여기](https://github.com/terrastruct/d2/blob/master/docs/INSTALL.md)에 Mac, Windows 및 Linux에서의 다양하고 자세한 설치 지침이 있습니다.
+[여기](https://github.com/d2lang/d2/blob/master/docs/INSTALL.md)에 Mac, Windows 및 Linux에서의 다양하고 자세한 설치 지침이 있습니다.
 이 페이지는 그에 대한 요약 버전입니다.
 :::
 
@@ -41,7 +41,7 @@ go install oss.terrastruct.com/d2@latest
 ```
 
 :::info
-[Github 릴리스 페이지](https://github.com/terrastruct/d2/releases)에서 OS에 맞게 미리 컴파일된 바이너리 파일을 다운로드할 수도 있습니다.
+[Github 릴리스 페이지](https://github.com/d2lang/d2/releases)에서 OS에 맞게 미리 컴파일된 바이너리 파일을 다운로드할 수도 있습니다.
 :::
 
 # 사용해보기

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/intro.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/intro.md
@@ -76,8 +76,8 @@ D2의 사용법을 알아보는 이 과정은 약 5~10분 안에 끝낼 수 있�
 
 :::info
 D2의 소스 코드는 다음에서 호스팅됩니다.
-[https://github.com/terrastruct/d2](https://github.com/terrastruct/d2).
+[https://github.com/d2lang/d2](https://github.com/d2lang/d2).
 
 이 문서의 소스 코드는 다음과 같습니다.
-[https://github.com/terrastruct/d2-docs](https://github.com/terrastruct/d2-docs).
+[https://github.com/d2lang/d2-docs](https://github.com/d2lang/d2-docs).
 :::

--- a/src/components/Directory/MoreFeatures.jsx
+++ b/src/components/Directory/MoreFeatures.jsx
@@ -14,7 +14,7 @@ const moreFeatures = [
     description:
       "MacOS, Linux, and Windows. D2 is included in many popular package managers like Homebrew and Winget.",
     icon: "os.svg",
-    href: "https://github.com/terrastruct/d2/releases",
+    href: "https://github.com/d2lang/d2/releases",
   },
   {
     title: "VSCode and Vim",


### PR DESCRIPTION
## What changed

- Update active D2, Docs, Playground, VS Code, Vim, and Obsidian repository links to the d2lang organization.
- Update the d2-vscode submodule URL while retaining the shared terrastruct/ci submodule.
- Update current installation, editor, community, release, blog, and Korean documentation references.

## Validation

- Docusaurus production build completed successfully for English and Korean.
- git diff --check passed.
- Remaining old repository links are confined to historical release content or unchanged submodules.