### PR TITLE
Deploy docs through AWS OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
     needs: [ci, nofixups, spell-check, alt-tags-check, webp-versions-check]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      D2_DOCS_S3_BUCKET: s3://d2lang-docs-278852893615
+      D2_DOCS_CLOUDFRONT_ID: E2NLB7I775SAF
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,14 +82,11 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::278852893615:role/d2lang-docs-deploy
           aws-region: us-west-1
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Deploy to production
         run: ./ci/deploy.sh
         env:
-          D2_DOCS_S3_BUCKET: ${{ secrets.D2_DOCS_S3_BUCKET }}
-          D2_DOCS_CLOUDFRONT_ID: ${{ secrets.D2_DOCS_CLOUDFRONT_ID }}
           D2_DOCS_ALGOLIA_CRAWLER_API_KEY: ${{ secrets.D2_DOCS_ALGOLIA_CRAWLER_API_KEY }}

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -21,11 +21,10 @@ fi
 
 DOCUSAURUS_IGNORE_SSG_WARNINGS=true npm run prod
 aws sts get-caller-identity --no-cli-pager > /dev/null
-aws s3 sync ./build ${D2_DOCS_S3_BUCKET} --delete --acl public-read --no-cli-pager
+aws s3 sync ./build ${D2_DOCS_S3_BUCKET} --delete --no-cli-pager
 aws cloudfront create-invalidation --distribution-id ${D2_DOCS_CLOUDFRONT_ID} --paths "/*" --no-cli-pager
 
 curl -H "Content-Type: application/json" \
   -X POST \
   --user dd0bd3fe-db42-4673-89ae-e7e70dfae16b:${D2_DOCS_ALGOLIA_CRAWLER_API_KEY} \
   "https://crawler.algolia.com/api/1/crawlers/2d841c67-ab75-4fb1-9114-f8844363d74c/reindex"
-


### PR DESCRIPTION
## What changed

- grant the production deploy job GitHub OIDC token permission
- assume the new `d2lang-docs-deploy` AWS role instead of using static AWS access-key secrets
- point deployment at the new private docs bucket and CloudFront distribution
- retain the Algolia crawler API key as a GitHub secret
- stop requesting the obsolete `public-read` object ACL

## Why

The D2 docs deployment needs to move from Terrastruct-owned AWS credentials and infrastructure to the personally owned D2 AWS stack. The new S3 bucket uses private CloudFront origin access, so object-level public ACLs are neither needed nor accepted.

## Impact

After this is merged, successful pushes to `master` will deploy the docs build to `s3://d2lang-docs-278852893615` and invalidate CloudFront distribution `E2NLB7I775SAF` using short-lived OIDC credentials. This PR does not change production DNS and does not deploy from the PR branch.

## Validation

- parsed `.github/workflows/ci.yml` with Ruby YAML
- ran `bash -n ci/deploy.sh`
- ran `git diff --check`
- verified the AWS role trust is restricted to the immutable `d2lang/d2-docs` repository identity on `master`
- verified the role policy targets the configured S3 bucket and CloudFront distribution
