### PR TITLE
Update transferred dependency links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/d2lang/d2-vscode
 [submodule "ci/sub"]
 	path = ci/sub
-	url = https://github.com/terrastruct/ci
+	url = https://github.com/d2lang/ci

--- a/docs/releases/0.2.5.md
+++ b/docs/releases/0.2.5.md
@@ -23,6 +23,6 @@ Customizations and layouts take a big leap forward with this release! Put togeth
 
 #### Bugfixes ⛑️
 
-- Fixes `d2` erroring on malformed user paths (`fdopendir` error). [util-go#10](https://github.com/terrastruct/util-go/pull/10)
+- Fixes `d2` erroring on malformed user paths (`fdopendir` error). [util-go#10](https://github.com/d2lang/util-go/pull/10)
 - Arrowhead labels being set without maps wasn't being picked up. [#1015](https://github.com/terrastruct/d2/pull/1015)
 - Fixes a `dagre` layout error with connections to a container shape with a blockstring label. [#1032](https://github.com/terrastruct/d2/pull/1032)


### PR DESCRIPTION
## What changed

- update canonical links from `terrastruct/ci` and `terrastruct/util-go` to their new `d2lang` repository locations
- keep the existing Go vanity module path unchanged

## Why

The dependency repositories have moved to the `d2lang` organization. New clones and contributors should use the canonical locations rather than GitHub compatibility redirects.

## Checks

- `git diff --check`
- transferred repository IDs and old-location redirects verified
