### PR TITLE
docs: use GitHub D2 module path

### DIFF
--- a/docs/releases/0.1.0.md
+++ b/docs/releases/0.1.0.md
@@ -32,7 +32,7 @@ If you want a fast way to check out what a change looks like, we put screenshots
 - Container default font styling is no longer bold. Everything used to look too bold. [#358](https://github.com/terrastruct/d2/pull/358)
 - `BROWSER=0` will disable opening a browser on `--watch`. [#311](https://github.com/terrastruct/d2/pull/311)
 - [install.sh](https://github.com/terrastruct/d2/blob/v0.1.0/docs/INSTALL.md) prints the dry run message more visibly. [#266](https://github.com/terrastruct/d2/pull/266)
-- `d2` now lives in the root folder of the repository instead of as a subcommand. So you can now run `go install oss.terrastruct.com/d2@latest` to install from source. [#290](https://github.com/terrastruct/d2/pull/290)
+- `d2` now lives in the root folder of the repository instead of as a subcommand, making it directly installable from source with Go. [#290](https://github.com/terrastruct/d2/pull/290)
 - `install.sh` defaults to installation to `/usr/local` as before but now if `/usr/local` is not accessible to the current user, it will use `~/.local` instead of prompting for sudo. You can pass `--prefix /usr/local` to force installation into `/usr/local` with a prompt for sudo. [#372](https://github.com/terrastruct/d2/pull/372)
 
 #### Bugfixes ⛑️
@@ -45,4 +45,3 @@ If you want a fast way to check out what a change looks like, we put screenshots
 - No longer log benign file-watching errors. [#293](https://github.com/terrastruct/d2/pull/293)
 - `$BROWSER` now works to open a custom browser correctly. For example, to open Firefox on macOS: `BROWSER='open -a Firefox'` [#311](https://github.com/terrastruct/d2/pull/311)
 - Fixes numbered IDs being wrongly positioned in `dagre` [#321](https://github.com/terrastruct/d2/issues/321).
-

--- a/docs/tour/install.md
+++ b/docs/tour/install.md
@@ -37,7 +37,7 @@ curl -fsSL https://d2lang.com/install.sh | sh -s -- --uninstall
 Alternatively, you can install from source:
 
 ```shell
-go install oss.terrastruct.com/d2@latest
+go install github.com/d2lang/d2@latest
 ```
 
 

--- a/docs/tour/man.md
+++ b/docs/tour/man.md
@@ -34,7 +34,7 @@ DESCRIPTION
      iteration on a broken diagram.
 
      See more docs, the source code and license at
-     https://oss.terrastruct.com/d2.
+     https://github.com/d2lang/d2.
 
      Hosted icons at https://icons.d2lang.com.
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/tour/install.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/tour/install.md
@@ -37,7 +37,7 @@ curl -fsSL https://d2lang.com/install.sh | sh -s -- --uninstall
 소스 파일로 설치할 수도 있습니다.
 
 ```shell
-go install oss.terrastruct.com/d2@latest
+go install github.com/d2lang/d2@latest
 ```
 
 :::info


### PR DESCRIPTION
## Summary
- update source-install commands to `github.com/d2lang/d2@latest`
- point the manual source URL at the d2lang GitHub repository
- remove the obsolete module path from the historical v0.1.0 note without rewriting its meaning

## Validation
- full docs formatter/build
- English and Korean production builds
- alt-tag check
- WebP version check
- `git diff --check`

The new path is live as the signed `v0.8.0` tag in d2lang/d2.